### PR TITLE
Checkout redesign & store filter URL sync

### DIFF
--- a/app/Livewire/Checkout/Shipping.php
+++ b/app/Livewire/Checkout/Shipping.php
@@ -31,6 +31,13 @@ final class Shipping extends StepComponent
         $this->sameAsShipping = (bool) session()->get(CheckoutSession::SAME_AS_SHIPPING);
     }
 
+    public function updatedSameAsShipping(): void
+    {
+        if (! $this->sameAsShipping) {
+            $this->billingAddressId = null;
+        }
+    }
+
     public function save(): void
     {
         $this->validate();

--- a/app/Livewire/Pages/Store.php
+++ b/app/Livewire/Pages/Store.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
 use Shopper\Core\Models\Attribute;
@@ -21,7 +22,8 @@ class Store extends Component
 
     public const int FILTERABLE_ATTRIBUTES_CACHE_TTL = 7200;
 
-    /** @var string[] */
+    /** @var array<string, string[]> */
+    #[Url(as: 'filters')]
     public array $selectedAttributes = [];
 
     /**
@@ -39,6 +41,27 @@ class Store extends Component
         );
     }
 
+    public function toggleAttribute(string $slug, string $valueId): void
+    {
+        if (! isset($this->selectedAttributes[$slug])) {
+            $this->selectedAttributes[$slug] = [];
+        }
+
+        if (in_array($valueId, $this->selectedAttributes[$slug])) {
+            $this->selectedAttributes[$slug] = array_values(
+                array_filter($this->selectedAttributes[$slug], fn (string $v): bool => $v !== $valueId)
+            );
+        } else {
+            $this->selectedAttributes[$slug][] = $valueId;
+        }
+
+        if (empty($this->selectedAttributes[$slug])) {
+            unset($this->selectedAttributes[$slug]);
+        }
+
+        $this->resetPage();
+    }
+
     public function render(): View
     {
         $query = Product::query()->publish()
@@ -48,9 +71,11 @@ class Store extends Component
             ->withCount('ratings')
             ->latest();
 
-        if (count($this->selectedAttributes) > 0) {
-            $query = $query->whereHas('options', function ($query): void {
-                $query->whereIn('attribute_value_id', $this->selectedAttributes);
+        $selectedIds = collect($this->selectedAttributes)->flatten()->filter()->all();
+
+        if (count($selectedIds) > 0) {
+            $query = $query->whereHas('options', function ($query) use ($selectedIds): void {
+                $query->whereIn('attribute_value_id', $selectedIds);
             });
         }
 

--- a/app/Livewire/Pages/Store.php
+++ b/app/Livewire/Pages/Store.php
@@ -55,7 +55,7 @@ class Store extends Component
             $this->selectedAttributes[$slug][] = $valueId;
         }
 
-        if (empty($this->selectedAttributes[$slug])) {
+        if (blank($this->selectedAttributes[$slug])) {
             unset($this->selectedAttributes[$slug]);
         }
 

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -131,7 +131,7 @@ return [
 
     'navigate' => [
         'show_progress_bar' => true,
-        'progress_bar_color' => '#2299dd',
+        'progress_bar_color' => '#155DFC',
     ],
 
     /*

--- a/config/starter-kit.php
+++ b/config/starter-kit.php
@@ -34,4 +34,13 @@ return [
 
     'default_zone' => env('SHOPPER_DEFAULT_ZONE', 'AF'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Display Discount banner
+    |--------------------------------------------------------------------------
+    |
+    */
+
+    'display_banner' => env('SHOPPER_DISPLAY_BANNER', false),
+
 ];

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -11,6 +11,13 @@
 @source "../../vendor/laravelcm/livewire-slide-overs/resources/views/*.blade.php";
 @source "../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php";
 
+@layer base {
+  button, [role="button"], a, select, summary,
+  [type="button"], [type="reset"], [type="submit"] {
+    cursor: pointer;
+  }
+}
+
 @theme {
   --font-sans: 'Inter var', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --font-heading: 'Figtree', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
@@ -57,4 +64,3 @@
   --color-success-900: var(--color-green-900);
   --color-success-950: var(--color-green-950);
 }
-

--- a/resources/views/components/attributes/color.blade.php
+++ b/resources/views/components/attributes/color.blade.php
@@ -1,6 +1,8 @@
-@props(['attribute'])
+@props([
+    'attribute',
+])
 
-<div wire:key="{{ $attribute->id }}" x-data="{ selectedColorAttributes: @entangle('selectedAttributes') }" class="py-6">
+<div wire:key="{{ $attribute->id }}" x-data="{ selectedColorAttributes: @entangle('selectedAttributes.' . $attribute->slug) }" class="py-6">
     <p class="block text-sm font-medium text-zinc-900">{{ $attribute->name }}</p>
 
     @if ($attribute->values->isNotEmpty())
@@ -11,18 +13,17 @@
                         class="relative -m-0.5 flex cursor-pointer items-center justify-center rounded p-0.5"
                     >
                         <input id="{{ $attribute->slug }}-{{ $value->id }}"
-                               wire:model.live.debounce.350ms="selectedAttributes"
                                type="checkbox"
                                class="sr-only"
                                value="{{ $value->id }}"
-                               wire:model.live.debounce.350ms="selectedAttributes"
-                               :checked="selectedColorAttributes.includes('{{ $value->id }}')"
+                               :checked="(selectedColorAttributes || []).includes('{{ $value->id }}')"
+                               x-on:change="$wire.toggleAttribute('{{ $attribute->slug }}', '{{ $value->id }}')"
                         />
                         <span
                             aria-hidden="true"
                             style="background-color: {{ $value->key }} "
                             class="size-6 rounded-full "
-                            :class="selectedColorAttributes.includes('{{ $value->id }}') ? 'ring-2 ring-primary-600 ring-offset-2' : 'border-double border-2 border-black/10' "
+                            :class="(selectedColorAttributes || []).includes('{{ $value->id }}') ? 'ring-2 ring-primary-600 ring-offset-2' : 'border-double border-2 border-black/10' "
                         ></span>
                     </label>
                 </div>

--- a/resources/views/components/attributes/size.blade.php
+++ b/resources/views/components/attributes/size.blade.php
@@ -1,6 +1,8 @@
-@props(['attribute'])
+@props([
+    'attribute',
+])
 
-<div wire:key="{{ $attribute->id }}" x-data="{ selectedAttributes: @entangle('selectedAttributes') }" class="py-6">
+<div wire:key="{{ $attribute->id }}" x-data="{ selectedAttributes: @entangle('selectedAttributes.'. $attribute->slug) }" class="py-6">
     <p class="block text-sm font-medium text-zinc-900">{{ $attribute->name }}</p>
     @if ($attribute->values->isNotEmpty())
         <div class="grid grid-cols-3 gap-3 sm:grid-cols-5 mt-6">
@@ -9,11 +11,10 @@
                     class="flex items-center justify-center px-3 py-3 text-sm font-medium uppercase border cursor-pointer focus:outline-none sm:flex-1 rounded-md"
                     :class="selectedAttributes.includes('{{ $value->id }}') ? 'border-transparent bg-primary-600 text-white hover:bg-primary-700' : 'border-zinc-200 bg-white text-zinc-900 hover:bg-zinc-50'">
                     <input id="{{ $attribute->slug }}-{{ $value->id }}"
-                        wire:model.live.debounce.350ms="selectedAttributes"
+                        wire:model.live.debounce.350ms="selectedAttributes.{{ $attribute->slug }}"
                         type="checkbox"
                         class="sr-only"
                         value="{{ $value->id }}"
-                        wire:model.live.debounce.350ms="selectedAttributes"
                         :checked="selectedAttributes.includes('{{ $value->id }}')"
                     />
                     <span>{{ $value->value }}</span>

--- a/resources/views/components/cart/element.blade.php
+++ b/resources/views/components/cart/element.blade.php
@@ -9,23 +9,24 @@
     $model = $item->associatedModel instanceof \App\Models\ProductVariant ? $item->associatedModel->product : $item->associatedModel;
 @endphp
 
-<li class="flex items-start py-6 space-x-4">
-    <x-products.thumbnail :product="$item->associatedModel" class="size-20 border aspect-none border-primary-700" />
-    <div class="flex-auto">
-        <h3 class="font-medium font-heading text-white">
-            <x-link :href="route('single-product', $model)">
-                {{ $item->name }}
-            </x-link>
+<li class="flex items-start py-4 gap-4">
+    <div class="relative shrink-0">
+        <x-products.thumbnail :product="$item->associatedModel" class="size-16 rounded-lg border border-zinc-200" />
+        @if ($item->quantity > 0)
+            <span class="absolute -top-2 -right-2 flex items-center justify-center size-5 rounded-full bg-zinc-500 text-white text-xs font-medium">
+                {{ $item->quantity }}
+            </span>
+        @endif
+    </div>
+    <div class="flex-auto min-w-0">
+        <h3 class="text-sm font-medium text-zinc-900 truncate">
+            {{ $item->name }}
         </h3>
 
-        <p class="mt-1 text-zinc-300">
-            {{ __(':qty x :price', ['qty' => $item->quantity, 'price' => shopper_money_format($item->price, current_currency())]) }}
-        </p>
-
         @if ($item->attributes->isNotEmpty())
-            <ul class="mt-2">
+            <ul class="mt-1">
                 @foreach ($item->attributes as $name => $value)
-                    <li class="text-xs text-white">
+                    <li class="text-xs text-zinc-500">
                         <span class="font-medium text-zinc-400">{{ $name }}</span>:
                         <span>{{ $value }}</span>
                     </li>
@@ -33,7 +34,7 @@
             </ul>
         @endif
     </div>
-    <p class="flex-none text-base font-medium">
+    <p class="shrink-0 text-sm font-medium text-zinc-900">
         {{ $price }}
     </p>
 </li>

--- a/resources/views/components/checkout-summary.blade.php
+++ b/resources/views/components/checkout-summary.blade.php
@@ -1,0 +1,52 @@
+@php
+    $shippingAddress = session()->get(\App\CheckoutSession::SHIPPING_ADDRESS);
+    $shippingOption = session()->get(\App\CheckoutSession::SHIPPING_OPTION);
+    $stepsArray = collect($steps)->values();
+@endphp
+
+@if ($shippingAddress)
+    <div class="rounded-lg border border-zinc-200 divide-y divide-zinc-200 text-sm">
+        <div class="flex items-center justify-between px-4 py-3">
+            <div class="flex items-baseline gap-6">
+                <span class="text-zinc-500 w-16 shrink-0">{{ __('Contact') }}</span>
+                <span class="text-zinc-900">{{ auth()->user()->email }}</span>
+            </div>
+            @if ($stepsArray->get(0)?->complete)
+                <button wire:click="{{ $stepsArray->get(0)->show() }}" class="text-primary-600 hover:text-primary-700 text-xs font-medium shrink-0">
+                    {{ __('Change') }}
+                </button>
+            @endif
+        </div>
+
+        <div class="flex items-center justify-between px-4 py-3">
+            <div class="flex items-baseline gap-6">
+                <span class="text-zinc-500 w-16 shrink-0">{{ __('Ship to') }}</span>
+                <span class="text-zinc-900">
+                    {{ $shippingAddress['street_address'] }}, {{ $shippingAddress['city'] }} {{ $shippingAddress['postal_code'] }}
+                </span>
+            </div>
+            @if ($stepsArray->get(0)?->complete)
+                <button wire:click="{{ $stepsArray->get(0)->show() }}" class="text-primary-600 hover:text-primary-700 text-xs font-medium shrink-0">
+                    {{ __('Change') }}
+                </button>
+            @endif
+        </div>
+
+        @if ($shippingOption)
+            <div class="flex items-center justify-between px-4 py-3">
+                <div class="flex items-baseline gap-6">
+                    <span class="text-zinc-500 w-16 shrink-0">{{ __('Method') }}</span>
+                    <span class="text-zinc-900">
+                        {{ $shippingOption[0]['name'] }} &middot;
+                        {{ shopper_money_format($shippingOption[0]['price'], \App\Actions\ZoneSessionManager::getSession()->currencyCode) }}
+                    </span>
+                </div>
+                @if ($stepsArray->get(1)?->complete)
+                    <button wire:click="{{ $stepsArray->get(1)->show() }}" class="text-primary-600 hover:text-primary-700 text-xs font-medium shrink-0">
+                        {{ __('Change') }}
+                    </button>
+                @endif
+            </div>
+        @endif
+    </div>
+@endif

--- a/resources/views/components/icons/payments/cash.blade.php
+++ b/resources/views/components/icons/payments/cash.blade.php
@@ -1,5 +1,5 @@
 <x-untitledui-coins-stacked-02
-    {{ $attributes->twMerge(['class' => 'size-8']) }}
-    stroke-width="1.5"
+    {{ $attributes->twMerge(['class' => 'size-8 text-zinc-500']) }}
+    stroke-width="1"
     aria-hidden="true"
 />

--- a/resources/views/components/layouts/header.blade.php
+++ b/resources/views/components/layouts/header.blade.php
@@ -1,4 +1,7 @@
-<x-banner />
+@if (config('starter-kit.display_banner'))
+    <x-banner />
+@endif
+
 <header class="sticky top-0 z-10 py-3 bg-white/80 border-b border-zinc-200 backdrop-blur-xl">
     <x-container class="flex items-center justify-between px-4">
         <nav role="navigation" class="hidden lg:flex gap-4 lg:flex-1 lg:self-stretch">

--- a/resources/views/components/order/index.blade.php
+++ b/resources/views/components/order/index.blade.php
@@ -20,7 +20,7 @@
             @endforeach
         </div>
         <div class="grid grid-cols-2 gap-x-5 lg:flex lg:flex-col lg:items-end lg:justify-end lg:space-y-2 lg:pl-4">
-            <flux:button variant="primary" class="w-full" :href="route('dashboard.orders.detail', ['number' => $order->number])">
+            <flux:button variant="primary" class="w-full" :href="route('dashboard.orders.detail', ['number' => $order->number])" wire:navigate>
                 {{ __('Show details') }}
             </flux:button>
             <flux:button class="w-full">

--- a/resources/views/components/products/card.blade.php
+++ b/resources/views/components/products/card.blade.php
@@ -3,7 +3,10 @@
 ])
 
 <div class="relative group">
-    <x-products.thumbnail :$product class='w-full rounded-lg h-56 lg:h-72 xl:h-80' />
+    <x-products.thumbnail
+        :$product
+        class='w-full rounded-lg lg:h-72 xl:h-80'
+    />
 
     <h3 class="mt-4 text-sm text-zinc-700 group-hover:text-zinc-900">
         <x-link :href="route('single-product', $product)">

--- a/resources/views/livewire/checkout/delivery.blade.php
+++ b/resources/views/livewire/checkout/delivery.blade.php
@@ -1,12 +1,19 @@
 <div class="flex flex-col justify-between space-y-10">
     @include('components.checkout-steps')
 
+    @include('components.checkout-summary')
+
     @if(count($options) === 0)
         <div class="flex items-center p-4 space-x-4 rounded-lg ring-1 ring-zinc-200">
             <x-untitledui-shopping-bag class="size-5 text-primary-800" stroke-width="1.5" aria-hidden="true" />
             <p class="text-sm text-zinc-500">
                 {{ __('No delivery option available for your address.') }}
             </p>
+        </div>
+        <div class="pt-6 border-t border-zinc-200">
+            <button wire:click="previousStep" type="button" class="text-sm text-primary-600 hover:text-primary-700">
+                <span>&larr;</span> {{ __('Return to information') }}
+            </button>
         </div>
     @else
         <form wire:submit="save" class="flex-1 space-y-3">
@@ -44,7 +51,7 @@
 
                 <div class="pt-6 mt-10 border-t border-zinc-200 sm:flex sm:items-center sm:justify-end">
                     <flux:button variant="primary" type="submit" class="w-full sm:w-auto">
-                        {{ __('Go to checkout') }}
+                        {{ __('Continue to payment') }}
                     </flux:button>
                 </div>
             </div>

--- a/resources/views/livewire/checkout/payment.blade.php
+++ b/resources/views/livewire/checkout/payment.blade.php
@@ -1,11 +1,18 @@
 <div class="flex flex-col justify-between space-y-10">
     @include('components.checkout-steps')
 
+    @include('components.checkout-summary')
+
     <form wire:submit="save" class="flex-1 space-y-3">
         <flux:error name="currentSelected" />
 
         <div class="max-w-lg mx-auto lg:max-w-none">
-            <flux:radio.group wire:model.live.debounce="currentSelected" variant="cards" class="flex-col">
+            <div>
+                <flux:heading size="lg">{{ __('Payment method') }}</flux:heading>
+                <flux:subheading>{{ __('All transactions are secure and encrypted.') }}</flux:subheading>
+            </div>
+
+            <flux:radio.group wire:model.live.debounce="currentSelected" variant="cards" class="flex-col mt-5">
                 @foreach ($methods as $method)
                     <flux:radio value="{{ $method->id }}" class="w-full">
                         <div class="flex items-center justify-between w-full">
@@ -29,17 +36,16 @@
                 @endforeach
             </flux:radio.group>
 
-            <div class="mt-8 space-y-8">
+            <div class="mt-8">
                 <p class="text-sm leading-5 text-zinc-500">
-                    {{ __(" By clicking on the 'Place my order' button, you confirm that you have read,
-                     understood and accepted our terms of use, our terms of sale and our returns policy,
-                      and you acknowledge that you have read our privacy policy.") }}
+                    {{ __("By clicking on the 'Place my order' button, you confirm that you have read, understood and accepted our terms of use, our terms of sale and our returns policy, and you acknowledge that you have read our privacy policy.") }}
                 </p>
-                <div class="pt-6 border-t border-zinc-200 sm:flex sm:items-center sm:justify-end">
-                    <flux:button variant="primary" type="submit" class="w-full sm:w-auto">
-                        {{ __('Place my order') }}
-                    </flux:button>
-                </div>
+            </div>
+
+            <div class="pt-6 mt-6 border-t border-zinc-200 sm:flex sm:items-center sm:justify-end">
+                <flux:button type="submit" variant="primary" class="w-full sm:w-auto">
+                    {{ __('Place my order') }}
+                </flux:button>
             </div>
         </div>
     </form>

--- a/resources/views/livewire/checkout/shipping.blade.php
+++ b/resources/views/livewire/checkout/shipping.blade.php
@@ -64,16 +64,24 @@
                     </div>
                 </div>
 
-                <div class="pt-6 mt-10 border-t border-zinc-200 sm:flex sm:items-center sm:justify-end">
-                    <flux:button variant="primary" type="submit" class="w-full sm:w-auto">
-                        {{ __('Continue') }}
+                <div class="pt-6 mt-10 border-t border-zinc-200 flex items-center justify-between">
+                    <x-link :href="route('store')" class="text-sm text-primary-600 hover:text-primary-700">
+                        <span>&larr;</span> {{ __('Return to cart') }}
+                    </x-link>
+                    <flux:button variant="primary" type="submit">
+                        {{ __('Continue to shipping') }}
                     </flux:button>
                 </div>
             </div>
         </form>
     @else
-        <div class="p-4 text-sm font-medium leading-6 text-zinc-700 bg-zinc-50">
+        <div class="p-4 text-sm font-medium leading-6 text-zinc-700 bg-zinc-50 rounded-lg">
             {{ __('You don\'t have a corresponding address.') }}
+        </div>
+        <div class="pt-6 border-t border-zinc-200">
+            <x-link :href="route('store')" class="text-sm text-primary-600 hover:text-primary-700">
+                <span>&larr;</span> {{ __('Return to cart') }}
+            </x-link>
         </div>
     @endif
 </div>

--- a/resources/views/livewire/pages/checkout.blade.php
+++ b/resources/views/livewire/pages/checkout.blade.php
@@ -1,62 +1,67 @@
 <div class="bg-white">
-    <!-- Background color split screen for large screens -->
     <div class="fixed top-0 left-0 hidden w-1/2 h-full bg-white lg:block" aria-hidden="true"></div>
-    <div class="fixed top-0 right-0 hidden w-1/2 h-full bg-primary-800 lg:block" aria-hidden="true"></div>
+    <div class="fixed top-0 right-0 hidden w-1/2 h-full bg-zinc-50 border-l border-zinc-200 lg:block" aria-hidden="true"></div>
 
-    <header class="relative text-sm font-medium text-zinc-700 bg-white border-b border-zinc-200">
+    <header class="relative border-b border-zinc-200 bg-white">
         <x-container class="py-4">
-            <div class="relative flex items-center gap-10">
+            <div class="relative flex items-center justify-between">
                 <x-link :href="route('home')">
                     <span class="sr-only">{{ shopper_setting('legal_name') }}</span>
                     <x-brand class="w-auto h-10 text-primary-700" aria-hidden="true" />
                 </x-link>
-                <x-link :href="route('store')" class="inline-flex items-center gap-2 font-medium text-zinc-600 hover:text-zinc-900">
-                    <x-untitledui-arrow-narrow-left class="size-6 text-zinc-400" aria-hidden="true" stroke-width="1.5" />
+                <x-link :href="route('store')" class="inline-flex items-center gap-2 text-sm font-medium text-zinc-600 hover:text-zinc-900">
+                    <x-untitledui-arrow-narrow-left class="size-5 text-zinc-400" aria-hidden="true" stroke-width="1.5" />
                     {{ __('Back to Shopping Cart') }}
                 </x-link>
             </div>
-         </x-container>
+        </x-container>
     </header>
 
-    <x-container class="relative grid grid-cols-1 gap-x-16 lg:grid-cols-2 xl:gap-x-48">
-        <h1 class="sr-only">{{ __('Order information') }}</h1>
+    <h1 class="sr-only">{{ __('Order information') }}</h1>
 
+    <x-container class="relative grid grid-cols-1 gap-x-16 lg:grid-cols-2 xl:gap-x-48">
         <section
             aria-labelledby="summary-heading"
-            class="px-4 pt-16 pb-10 bg-primary-950 sm:px-6 lg:col-start-2 lg:row-start-1 lg:bg-transparent lg:px-0 lg:pb-16"
+            class="px-4 pt-16 pb-10 bg-zinc-50 sm:px-6 lg:col-start-2 lg:row-start-1 lg:bg-transparent lg:px-0 lg:pb-16"
         >
             <div class="max-w-lg mx-auto lg:max-w-none">
-                <h2 id="summary-heading" class="text-lg font-medium text-white">
+                <h2 id="summary-heading" class="text-lg font-medium text-zinc-900">
                     {{ __('Cart summary') }}
                 </h2>
 
-                <ul role="list" class="text-sm font-medium text-white divide-y divide-white/10">
+                <ul role="list" class="text-sm font-medium divide-y divide-zinc-200">
                     @foreach ($items as $item)
                         <x-cart.element :$item />
                     @endforeach
                 </ul>
 
-                <dl class="hidden pt-6 space-y-6 text-sm font-medium text-white border-t border-white/10 lg:block">
+                <dl class="hidden pt-6 space-y-4 text-sm font-medium border-t border-zinc-200 lg:block">
                     <div class="flex items-center justify-between">
-                        <dt class="text-zinc-300">{{ __('Subtotal') }}</dt>
-                        <dd>
+                        <dt class="text-zinc-500">{{ __('Subtotal') }}</dt>
+                        <dd class="text-zinc-900">
                             {{ shopper_money_format(amount: $subtotal, currency: current_currency()) }}
                         </dd>
                     </div>
 
                     <div class="flex items-center justify-between">
-                        <dt class="text-zinc-300">{{ __('Delivery') }}</dt>
-                        <livewire:components.shipping-price />
+                        <dt class="text-zinc-500">{{ __('Shipping') }}</dt>
+                        <dd class="text-zinc-900">
+                            <livewire:components.shipping-price />
+                        </dd>
                     </div>
 
                     <div class="flex items-center justify-between">
-                        <dt class="text-zinc-300">{{ __('Tax') }}</dt>
-                        <livewire:components.tax-price />
+                        <dt class="text-zinc-500">{{ __('Tax') }}</dt>
+                        <dd class="text-zinc-900">
+                            <livewire:components.tax-price />
+                        </dd>
                     </div>
 
-                    <div class="flex items-center justify-between pt-6 border-t border-white/10">
-                        <dt class="text-base">{{ __('Total') }}</dt>
-                        <livewire:components.cart-total />
+                    <div class="flex items-center justify-between pt-6 border-t border-zinc-200">
+                        <dt class="text-base text-zinc-900">{{ __('Total') }}</dt>
+                        <dd class="text-base text-zinc-900">
+                            <livewire:components.cart-total />
+                        </dd>
                     </div>
                 </dl>
 
@@ -64,13 +69,13 @@
                     <div
                         x-data="{ open: false }"
                         @keydown.escape="open = false"
-                        class="fixed inset-x-0 bottom-0 flex flex-col-reverse text-sm font-medium text-white lg:hidden"
+                        class="fixed inset-x-0 bottom-0 flex flex-col-reverse text-sm font-medium lg:hidden"
                     >
-                        <div class="relative z-10 px-4 bg-white border-t border-white/10 sm:px-6">
+                        <div class="relative z-10 px-4 bg-white border-t border-zinc-200 sm:px-6">
                             <div class="max-w-lg mx-auto">
                                 <button
                                     type="button"
-                                    class="flex items-center w-full py-6 font-medium"
+                                    class="flex items-center w-full py-6 font-medium text-zinc-900"
                                     aria-expanded="false"
                                     @click="open = !open"
                                 >
@@ -78,17 +83,8 @@
                                     <span class="mr-2 text-base">
                                         <livewire:components.cart-total />
                                     </span>
-                                    <svg
-                                        class="size-5 text-zinc-500"
-                                        viewBox="0 0 20 20"
-                                        fill="currentColor"
-                                        aria-hidden="true"
-                                    >
-                                        <path
-                                            fill-rule="evenodd"
-                                            d="M14.77 12.79a.75.75 0 01-1.06-.02L10 8.832 6.29 12.77a.75.75 0 11-1.08-1.04l4.25-4.5a.75.75 0 011.08 0l4.25 4.5a.75.75 0 01-.02 1.06z"
-                                            clip-rule="evenodd"
-                                        />
+                                    <svg class="size-5 text-zinc-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd" d="M14.77 12.79a.75.75 0 01-1.06-.02L10 8.832 6.29 12.77a.75.75 0 11-1.08-1.04l4.25-4.5a.75.75 0 011.08 0l4.25 4.5a.75.75 0 01-.02 1.06z" clip-rule="evenodd" />
                                     </svg>
                                 </button>
                             </div>
@@ -124,20 +120,24 @@
                             >
                                 <dl class="max-w-lg mx-auto space-y-6">
                                     <div class="flex items-center justify-between">
-                                        <dt class="text-zinc-400">{{ __('SubTotal') }}</dt>
-                                        <dd>
+                                        <dt class="text-zinc-500">{{ __('Subtotal') }}</dt>
+                                        <dd class="text-zinc-900">
                                             {{ shopper_money_format(amount: $subtotal, currency: current_currency()) }}
                                         </dd>
                                     </div>
 
                                     <div class="flex items-center justify-between">
-                                        <dt class="text-zinc-400">{{ __('Delivery') }}</dt>
-                                        <livewire:components.shipping-price />
+                                        <dt class="text-zinc-500">{{ __('Shipping') }}</dt>
+                                        <dd class="text-zinc-900">
+                                            <livewire:components.shipping-price />
+                                        </dd>
                                     </div>
 
                                     <div class="flex items-center justify-between">
-                                        <dt class="text-zinc-400">{{ __('Tax') }}</dt>
-                                        <livewire:components.tax-price />
+                                        <dt class="text-zinc-500">{{ __('Tax') }}</dt>
+                                        <dd class="text-zinc-900">
+                                            <livewire:components.tax-price />
+                                        </dd>
                                     </div>
                                 </dl>
                             </div>
@@ -147,7 +147,7 @@
             </div>
         </section>
 
-        <div class="px-4 pt-16 pb-36 sm:px-6 lg:col-start-1 lg:row-start-1 lg:px-0 lg:pb-16">
+        <div class="flex flex-col gap-10 justify-between px-4 pt-16 sm:px-6 lg:col-start-1 lg:row-start-1 lg:px-0 h-full">
             <livewire:checkout-wizard />
         </div>
     </x-container>

--- a/resources/views/livewire/pages/home.blade.php
+++ b/resources/views/livewire/pages/home.blade.php
@@ -24,7 +24,7 @@
                 <!-- Decorative image grid -->
                 @include('includes._decorative_images')
 
-                <flux:button variant="primary" :href="route('store')" class="group">
+                <flux:button variant="primary" :href="route('store')" class="group" wire:navigate>
                     {{ __('Discover now') }}
                     <span
                         class="ml-2 transition duration-200 ease-in-out transform translate-x-0 group-hover:translate-x-1">

--- a/resources/views/livewire/pages/home.blade.php
+++ b/resources/views/livewire/pages/home.blade.php
@@ -50,7 +50,7 @@
                     </x-link>
                 </div>
 
-                <div class="grid grid-cols-1 mt-6 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-4 lg:gap-x-8 lg:mt-18">
+                <div class="grid grid-cols-2 mt-6 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-4 lg:gap-x-8 lg:mt-18">
                     @foreach ($products as $product)
                         <x-products.card :$product />
                     @endforeach

--- a/resources/views/livewire/pages/single-product.blade.php
+++ b/resources/views/livewire/pages/single-product.blade.php
@@ -47,9 +47,9 @@
 
                 @if ($product->brand_id)
                     <a
-                        :href="{{ $product->brand->website ?? '#' }}"
+                        href="{{ $product->brand->website ?? '#' }}"
                         target="_blank"
-                        class="cursor-default mt-4 inline-flex font-medium text-primary-500 group group-link-underline"
+                        class="cursor-pointer mt-4 inline-flex font-medium text-primary-500 group group-link-underline"
                     >
                         <span class="link link-underline link-underline-primary">
                         {{ $product->brand->name }}</span>

--- a/resources/views/livewire/pages/store.blade.php
+++ b/resources/views/livewire/pages/store.blade.php
@@ -32,7 +32,7 @@
                                     <p class="block text-sm font-medium text-zinc-900">{{ $attribute->name }}</p>
                                     @if ($attribute->values->isNotEmpty())
                                         <div x-data="{ expanded: false }">
-                                            <flux:checkbox.group wire:model.live.debounce.350ms="selectedAttributes" class="pt-6 space-y-1.5">
+                                            <flux:checkbox.group wire:model.live.debounce.350ms="selectedAttributes.{{ $attribute->slug }}" class="pt-6 space-y-1.5">
                                                 @foreach ($attribute->values as $index => $value)
                                                     <div wire:key="{{ $attribute->slug }}-{{ $value->key }}" x-show="expanded || {{ $index }} < 6">
                                                         <flux:checkbox
@@ -65,7 +65,7 @@
                 <section aria-labelledby="product-heading" class="mt-6 lg:col-span-2 lg:mt-0 xl:col-span-3">
                     <h2 id="product-heading" class="sr-only">{{ __('Products') }}</h2>
 
-                    <div wire:loading.class="opacity-50 pointer-events-none" class="grid grid-cols-1 gap-x-6 gap-y-10 transition-opacity sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-x-8">
+                    <div wire:loading.class="opacity-50 pointer-events-none" class="grid grid-cols-2 gap-x-6 gap-y-10 transition-opacity sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-x-8">
                         @foreach ($products as $product)
                             <x-products.catalog-card :$product />
                         @endforeach

--- a/resources/views/vendor/breadcrumbs/tailwind.blade.php
+++ b/resources/views/vendor/breadcrumbs/tailwind.blade.php
@@ -3,15 +3,15 @@
         @if ($breadcrumbs->count() <= 4)
             @foreach ($breadcrumbs as $breadcrumb)
                 @if ($loop->first)
-                    <flux:breadcrumbs.item :href="$breadcrumb->url" icon="home" />
+                    <flux:breadcrumbs.item :href="$breadcrumb->url" icon="home" wire:navigate />
                 @elseif ($breadcrumb->url && ! $loop->last)
-                    <flux:breadcrumbs.item :href="$breadcrumb->url">{{ $breadcrumb->title }}</flux:breadcrumbs.item>
+                    <flux:breadcrumbs.item :href="$breadcrumb->url" wire:navigate>{{ $breadcrumb->title }}</flux:breadcrumbs.item>
                 @else
                     <flux:breadcrumbs.item>{{ $breadcrumb->title }}</flux:breadcrumbs.item>
                 @endif
             @endforeach
         @else
-            <flux:breadcrumbs.item :href="$breadcrumbs->first()->url" icon="home" />
+            <flux:breadcrumbs.item :href="$breadcrumbs->first()->url" icon="home" wire:navigate />
 
             @php
                 $middle = $breadcrumbs->slice(1, $breadcrumbs->count() - 3);
@@ -23,7 +23,7 @@
                     <flux:button icon="ellipsis-horizontal" variant="ghost" size="sm" />
                     <flux:navmenu>
                         @foreach ($middle as $breadcrumb)
-                            <flux:navmenu.item :href="$breadcrumb->url">{{ $breadcrumb->title }}</flux:navmenu.item>
+                            <flux:navmenu.item :href="$breadcrumb->url" wire:navigate>{{ $breadcrumb->title }}</flux:navmenu.item>
                         @endforeach
                     </flux:navmenu>
                 </flux:dropdown>
@@ -31,7 +31,7 @@
 
             @foreach ($last as $breadcrumb)
                 @if ($breadcrumb->url && ! $loop->last)
-                    <flux:breadcrumbs.item :href="$breadcrumb->url">{{ $breadcrumb->title }}</flux:breadcrumbs.item>
+                    <flux:breadcrumbs.item :href="$breadcrumb->url" wire:navigate>{{ $breadcrumb->title }}</flux:breadcrumbs.item>
                 @else
                     <flux:breadcrumbs.item>{{ $breadcrumb->title }}</flux:breadcrumbs.item>
                 @endif


### PR DESCRIPTION
## Summary
- **Store filters in URL**: Filters are now synced with URL query params (`?filters[size][]=4&filters[color][]=12`) for shareability and browser history
- **Cursor pointer fix**: Added global CSS fix for Tailwind CSS v4 preflight removing cursor-pointer on buttons
- **Checkout redesign**: Shopify-style clean layout with light theme, quantity badges on thumbnails, completed steps summary with "Change" links